### PR TITLE
提供无限循环数组嵌套功能

### DIFF
--- a/library/Validator.php
+++ b/library/Validator.php
@@ -85,9 +85,13 @@ final class Validator extends AllOf
     {
         $values = [];
         foreach ($rules as $field => $rule) {
-            $value = $rule->defaultType?$rule->default:($input[$field] ?? $rule->default);
-            $rule->check($value);
-            $values[$field] = $value;
+            if(is_array($rule)){
+                $values[$field] = $rule;
+            }else{
+                $value = $rule->defaultType?$rule->default:($input[$field] ?? $rule->default);
+                $rule->check($value);
+                $values[$field] = $value;
+            }
         }
         return $values;
     }


### PR DESCRIPTION
不好意思楼主，我考虑的不周到，input用作返回值的话，很多时候除了默认值，还会出现嵌入数组等情况，所以重新优化了下，使它可以适应更多的场景。比如：
```php
function addRule(Request $request, AuthService $authService){
        $data = v::input([], [
            'app_id' => v::alnum()->setDefault($request->route->param('app_id'),true)->setName('应用名'),
            'data' => v::input($request->all(), [
                'website_id' => v::intVal()->setDefault(0,true)->setName('站点id'),
                'rule' => v::stringVal()->setName('api对外路径'),
                'title' => v::stringVal()->setName('api接口名称'),
            ])
        ]);
        dump($data);
        return toTrue($authService->addRule($data));
    }
```