### PR TITLE
工作流程/更新移动

### DIFF
--- a/docs/rules/Mobile.md
+++ b/docs/rules/Mobile.md
@@ -1,0 +1,27 @@
+# Mobile
+
+- `Mobile()`
+
+```php
+v::mobile()->validate('13800138000'); // true
+v::mobile()->validate('+86 13800138000'); // false
+```
+
+## Categorization
+
+- Strings
+
+## Changelog
+
+Version | Description
+--------|-------------
+  0.5.0 | Created
+
+***
+See also:
+
+- [Phone](Phone.md)
+- [Email](Email.md)
+- [Json](Json.md)
+- [Url](Url.md)
+- [VideoUrl](VideoUrl.md)

--- a/library/ChainedValidator.php
+++ b/library/ChainedValidator.php
@@ -286,6 +286,7 @@ interface ChainedValidator extends Validatable
 
     public function phone(): ChainedValidator;
 
+    public function mobile(): ChainedValidator;
     public function phpLabel(): ChainedValidator;
 
     public function pis(): ChainedValidator;

--- a/library/Rules/Mobile.php
+++ b/library/Rules/Mobile.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Validation\Rules;
+
+use libphonenumber\NumberParseException;
+
+use function is_scalar;
+
+final class Mobile extends AbstractRule
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($input): bool
+    {
+        if (!is_scalar($input)) {
+            return false;
+        }
+
+        try {
+            // 此处使用简单的正则表达式检查中国大陆的手机号码格式
+            return preg_match('/^1[3456789]\d{9}$/', (string) $input) === 1;
+        } catch (NumberParseException $e) {
+            return false;
+        }
+    }
+}

--- a/library/StaticValidator.php
+++ b/library/StaticValidator.php
@@ -288,6 +288,7 @@ interface StaticValidator
 
     public static function phone(): ChainedValidator;
 
+    public static function mobile(): ChainedValidator;
     public static function phpLabel(): ChainedValidator;
 
     public static function pis(): ChainedValidator;

--- a/library/Validatable.php
+++ b/library/Validatable.php
@@ -40,6 +40,7 @@ interface Validatable
 
     public function setTemplate(string $template): Validatable;
 
+    public function setDefault(string $default, bool $defaultType=false): Validatable;
     /**
      * @param mixed $input
      */

--- a/library/Validator.php
+++ b/library/Validator.php
@@ -85,7 +85,7 @@ final class Validator extends AllOf
     {
         $values = [];
         foreach ($rules as $field => $rule) {
-            if(is_array($rule)){
+            if(is_array($rule) || !($rule instanceof \Respect\Validation\Validator)){
                 $values[$field] = $rule;
             }else{
                 $value = $rule->defaultType?$rule->default:($input[$field] ?? $rule->default);


### PR DESCRIPTION
1、添加了mobile用于国内手机号验证，官方的phone会把电话号码也验证通过
2、接口添加了setDefault，让使用->setDefault的方法后，ide也能自动跟踪，方便开发
3、input判断，添加了判断输入值是否\Respect\Validation\Validator，不是的话就直接赋值.

$data = v::input($request->post(), [
'aaa' => 1,
'phone' => v::optional(v::mobile())->setTemplate('未绑定/找到手机号'),
'code' => v::stringType()->notEmpty()->setName('验证码'),
'type' => v::intVal()->setDefault($this->data['type'],true)->setName('验证码类型'),
]);